### PR TITLE
Fixed issue #6: missing test for custom port and binding for qttasserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,18 @@ quickapp:
 quickapp-deps:
 	sudo apt install qml-module-qtquick-dialogs qml-module-qtquick-controls
 
-check:
+check: quickapp
 	set -e; \
 	source $(RVM_HOME)/.rvm/scripts/rvm;\
+	cd examples/quickapp;\
+	make check
+
+check-alt: quickapp
+	set -e; \
+	source $(RVM_HOME)/.rvm/scripts/rvm;\
+	export QTTASSERVER_HOST_BINDING="localhost";\
+	export QTTASSERVER_HOST_PORT=45535;\
+	export QTTASSERVER_SUT="sut_qt_custom_port";\
 	cd examples/quickapp;\
 	make check
 

--- a/examples/quickapp/tests/fute/cases/test_button.rb
+++ b/examples/quickapp/tests/fute/cases/test_button.rb
@@ -35,7 +35,7 @@ require "tdriver"
 class TestButton < Minitest::Test
   def setup
     # Setup cuTeDriver and settings identifiers
-    @sut = TDriver.sut('sut_qt')
+    @sut = TDriver.sut(ENV['QTTASSERVER_SUT'] || 'sut_qt')
     @sut.set_event_type(:Touch)
     @app = @sut.run(:name => 'quickapp',
                     :arguments => '-testability')

--- a/examples/quickapp/tests/fute/cases/test_children.rb
+++ b/examples/quickapp/tests/fute/cases/test_children.rb
@@ -35,7 +35,7 @@ require "tdriver"
 class TestChildren < Minitest::Test
   def setup
     # Setup cuTeDriver and settings identifiers
-    @sut = TDriver.sut('sut_qt')
+    @sut = TDriver.sut(ENV['QTTASSERVER_SUT'] || 'sut_qt')
     @sut.set_event_type(:Touch)
     @app = @sut.run(:name => 'quickapp',
                     :arguments => '-testability')

--- a/examples/quickapp/tests/fute/cases/test_children_flickable.rb
+++ b/examples/quickapp/tests/fute/cases/test_children_flickable.rb
@@ -35,7 +35,7 @@ require "tdriver"
 class TestChildrenFlickable < Minitest::Test
   def setup
     # Setup cuTeDriver and settings identifiers
-    @sut = TDriver.sut('sut_qt')
+    @sut = TDriver.sut(ENV['QTTASSERVER_SUT'] || 'sut_qt')
     @sut.set_event_type(:Touch)
     @app = @sut.run(:name => 'quickapp',
                     :arguments => '-testability')

--- a/examples/quickapp/tests/fute/cases/test_flickable.rb
+++ b/examples/quickapp/tests/fute/cases/test_flickable.rb
@@ -35,7 +35,7 @@ require "tdriver"
 class TestFlickable < Minitest::Test
   def setup
     # Setup cuTeDriver and settings identifiers
-    @sut = TDriver.sut('sut_qt')
+    @sut = TDriver.sut(ENV['QTTASSERVER_SUT'] || 'sut_qt')
     @sut.set_event_type(:Touch)
     @app = @sut.run(:name => 'quickapp',
                     :arguments => '-testability')

--- a/examples/quickapp/tests/fute/cases/test_window.rb
+++ b/examples/quickapp/tests/fute/cases/test_window.rb
@@ -35,7 +35,7 @@ require "tdriver"
 class TestWindow < Minitest::Test
   def setup
     # Setup cuTeDriver and settings identifiers
-    @sut = TDriver.sut('sut_qt')
+    @sut = TDriver.sut(ENV['QTTASSERVER_SUT'] || 'sut_qt')
     @sut.set_event_type(:Touch)
     @app = @sut.run(:name => 'quickapp',
                     :arguments => '-testability')

--- a/examples/quickapp/tests/fute/tdriver_parameters.xml
+++ b/examples/quickapp/tests/fute/tdriver_parameters.xml
@@ -8,6 +8,11 @@
 		<!-- use default values -->
 	</sut>
 
+	<sut id="sut_qt_custom_port" template="qt">
+		<parameter name="qttas_server_ip" value="127.0.0.1" />
+		<parameter name="qttas_server_port" value="45535" />
+	</sut>
+
 
   <!-- Add SUT configurations here. If Sut has specific configurations add them to config ini -->
 	<!-- Use Sut id as section for configuration -->


### PR DESCRIPTION
This adds "make check-alt" target to main level, which will enable the use of new environment variables for cutedriver-agent_qt, which allows the developer to set a custom port and use either "any" or "localhost" in host binding.